### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # scCNE_project
+The implement of CCNE on the scRNA-Seq dataset is shown as an example in this project. 
+The input data can be changed with the other four datasets if necessary.
+
+Calculating cell-specific causal network entropy (CCNE)
+input data: pericyte_to_neuron.xlsx, Undirected_ppi_network.txt
+output data: pericyte_to_neuron.mat
+running pipeline: CCNE.m
+
+Displaying result
+input data: pericyte_to_neuron.mat
+running pipeline: CCNE_main.m


### PR DESCRIPTION
The implement of CCNE on the scRNA-Seq dataset is shown as an example in this project. 
The input data can be changed with the other four datasets if necessary.

Calculating cell-specific causal network entropy (CCNE)
input data: pericyte_to_neuron.xlsx, Undirected_ppi_network.txt
output data: pericyte_to_neuron.mat
running pipeline: CCNE.m

Displaying result
input data: pericyte_to_neuron.mat
running pipeline: CCNE_main.m